### PR TITLE
Mark parameters as optional

### DIFF
--- a/sources/configuration.ts
+++ b/sources/configuration.ts
@@ -7,7 +7,7 @@ export const CATALOG_PROTOCOL = "catalog:";
 
 declare module "@yarnpkg/core" {
   interface ConfigurationValueMap {
-    catalogs: CatalogsConfiguration;
+    catalogs?: CatalogsConfiguration;
   }
 }
 
@@ -70,14 +70,14 @@ export class CatalogConfigurationReader {
     }
 
     // Get config from project configuration
-    const rawConfig = project.configuration.get("catalogs") as Record<
+    const rawConfig = (project.configuration.get("catalogs") || {}) as Record<
       string,
       object
     >;
 
     let config = rawConfig;
     // Transform config to handle root-level string values
-    config["list"] = Object.entries(rawConfig["list"] || {}).reduce(
+    config["list"] = Object.entries(rawConfig["list"]).reduce(
       (acc, [key, value]) => {
         if (typeof value === "string") {
           // If value is a string, put it under BASE_ALIAS_GROUP

--- a/sources/configuration.ts
+++ b/sources/configuration.ts
@@ -21,19 +21,19 @@ export interface CatalogsConfiguration {
      * - if list of alias groups, it will be used in order
      * - if 'max', the most frequently used alias group will be used
      */
-    default?: string[] | 'max';
+    default?: string[] | "max";
     /**
      * List of workspaces to ignore
      */
     ignoredWorkspaces?: string[];
-  }
+  };
   list?: {
     [alias: string]:
-    | {
-      [packageName: string]: string;
-    }
-    | string;
-  }
+      | {
+          [packageName: string]: string;
+        }
+      | string;
+  };
 }
 
 /**
@@ -70,11 +70,14 @@ export class CatalogConfigurationReader {
     }
 
     // Get config from project configuration
-    const rawConfig = project.configuration.get("catalogs") as unknown;
+    const rawConfig = project.configuration.get("catalogs") as Record<
+      string,
+      object
+    >;
 
     let config = rawConfig;
     // Transform config to handle root-level string values
-    config["list"] = Object.entries(rawConfig["list"] as Record<string, object>).reduce(
+    config["list"] = Object.entries(rawConfig["list"] || {}).reduce(
       (acc, [key, value]) => {
         if (typeof value === "string") {
           // If value is a string, put it under BASE_ALIAS_GROUP
@@ -118,9 +121,9 @@ export class CatalogConfigurationReader {
     const aliasGroupToFind =
       aliasGroup.length === 0 ? ROOT_ALIAS_GROUP : aliasGroup;
 
-    const aliasConfig = config.list[aliasGroupToFind];
+    const aliasConfig = config.list?.[aliasGroupToFind];
 
-    if (!aliasConfig) {
+    if (!aliasConfig || typeof aliasConfig === "string") {
       throw new CatalogConfigurationError(
         `Alias "${aliasGroupToFind}" not found in .yarnrc.yml catalogs.`,
         CatalogConfigurationError.INVALID_ALIAS
@@ -163,22 +166,31 @@ export class CatalogConfigurationReader {
 
         // If default value is "max", find the most frequently used alias group
         if (config.options.default === "max") {
-          const aliasGroups = Object.keys(config.list);
+          const aliasGroups = Object.keys(config.list || {});
 
-          const dependencies = [...workspace.manifest.dependencies, ...workspace.manifest.devDependencies];
-          const counts: Record<string, number> = Object.fromEntries(aliasGroups.map((aliasGroup) => [aliasGroup, 0]));
+          const dependencies = [
+            ...workspace.manifest.dependencies,
+            ...workspace.manifest.devDependencies,
+          ];
+          const counts: Record<string, number> = Object.fromEntries(
+            aliasGroups.map((aliasGroup) => [aliasGroup, 0])
+          );
 
           // Count the occurrences of each alias group in the dependencies
           for (const [_, descriptor] of dependencies) {
             if (descriptor.range.startsWith(CATALOG_PROTOCOL)) {
-              const aliasGroup = descriptor.range.substring(CATALOG_PROTOCOL.length);
+              const aliasGroup = descriptor.range.substring(
+                CATALOG_PROTOCOL.length
+              );
               counts[aliasGroup] = (counts[aliasGroup] || 0) + 1;
             }
           }
 
           // Find the alias group with the maximum count of dependencies
           const maxCount = Math.max(...Object.values(counts));
-          return Object.keys(counts).filter((aliasGroup) => counts[aliasGroup] === maxCount);
+          return Object.keys(counts).filter(
+            (aliasGroup) => counts[aliasGroup] === maxCount
+          );
         }
       }
     }
@@ -192,24 +204,29 @@ export class CatalogConfigurationReader {
    */
   async findDependency(
     project: Project,
-    dependency: Descriptor,
+    dependency: Descriptor
   ): Promise<[string, string][]> {
     const dependencyString = structUtils.stringifyIdent(dependency);
 
     const config = await this.readConfiguration(project);
 
-    const aliasGroups = Object.entries(config.list).filter(([_, value]) => {
-      if (typeof value === "string") {
-        return dependencyString === value;
-      } else {
-        return Object.keys(value).includes(dependencyString);
+    const aliasGroups = Object.entries(config.list || {}).filter(
+      ([_, value]) => {
+        if (typeof value === "string") {
+          return dependencyString === value;
+        } else {
+          return Object.keys(value).includes(dependencyString);
+        }
       }
-    });
+    );
 
     if (aliasGroups.length === 0) return [];
 
     return aliasGroups.map(([alias, aliasConfig]) => {
-      const version = typeof aliasConfig === "string" ? aliasConfig : aliasConfig[dependencyString];
+      const version =
+        typeof aliasConfig === "string"
+          ? aliasConfig
+          : aliasConfig[dependencyString];
       return [alias, version];
     });
   }
@@ -232,7 +249,7 @@ export class CatalogConfigurationReader {
     if (config.options?.ignoredWorkspaces) {
       return isMatch(
         structUtils.stringifyIdent(workspace.manifest.name),
-        config.options.ignoredWorkspaces,
+        config.options.ignoredWorkspaces
       );
     }
 
@@ -247,7 +264,11 @@ export class CatalogConfigurationReader {
     }
 
     // The list property must be an object
-    if (!config["list"] || typeof config["list"] !== "object") {
+    if (
+      !("list" in config) ||
+      !config["list"] ||
+      typeof config["list"] !== "object"
+    ) {
       return false;
     }
 
@@ -264,8 +285,15 @@ export class CatalogConfigurationReader {
     }
 
     // Check the default option if it exists
-    if (config["options"]) {
-      if (config["options"]["ignoredWorkspaces"]) {
+    if (
+      "options" in config &&
+      config["options"] &&
+      typeof config["options"] === "object"
+    ) {
+      if (
+        "ignoredWorkspaces" in config["options"] &&
+        config["options"]["ignoredWorkspaces"]
+      ) {
         if (!Array.isArray(config["options"]["ignoredWorkspaces"])) {
           return false;
         }
@@ -275,7 +303,7 @@ export class CatalogConfigurationReader {
         }
       }
 
-      if (config["options"]["default"]) {
+      if ("default" in config["options"] && config["options"]["default"]) {
         if (Array.isArray(config["options"]["default"])) {
           if (config["options"]["default"].length === 0) {
             return false;

--- a/sources/configuration.ts
+++ b/sources/configuration.ts
@@ -27,7 +27,7 @@ export interface CatalogsConfiguration {
      */
     ignoredWorkspaces?: string[];
   }
-  list: {
+  list?: {
     [alias: string]:
     | {
       [packageName: string]: string;

--- a/sources/index.ts
+++ b/sources/index.ts
@@ -8,8 +8,8 @@ import {
   Workspace,
   MessageName,
 } from "@yarnpkg/core";
-import { Hooks as EssentialHooks } from '@yarnpkg/plugin-essentials';
-import chalk from 'chalk';
+import { Hooks as EssentialHooks } from "@yarnpkg/plugin-essentials";
+import chalk from "chalk";
 import {
   CatalogConfigurationReader,
   CatalogConfigurationError,
@@ -20,7 +20,7 @@ import {
 
 declare module "@yarnpkg/core" {
   interface ConfigurationValueMap {
-    catalogs: CatalogsConfiguration;
+    catalogs?: CatalogsConfiguration;
   }
 }
 
@@ -44,10 +44,13 @@ const plugin: Plugin<Hooks & EssentialHooks> = {
         ...Object.values(workspace.manifest.raw["devDependencies"] || {}),
       ].some((version) => (version as string).startsWith(CATALOG_PROTOCOL));
 
-      if (await configReader.shouldIgnoreWorkspace(workspace) && hasCatalogProtocol) {
+      if (
+        (await configReader.shouldIgnoreWorkspace(workspace)) &&
+        hasCatalogProtocol
+      ) {
         report.reportError(
           MessageName.INVALID_MANIFEST,
-          `Workspace is ignored from the catalogs, but it has dependencies with the catalog protocol. Consider removing the protocol.`,
+          `Workspace is ignored from the catalogs, but it has dependencies with the catalog protocol. Consider removing the protocol.`
         );
       }
     },
@@ -127,30 +130,51 @@ const plugin: Plugin<Hooks & EssentialHooks> = {
         throw error;
       }
     },
-    afterWorkspaceDependencyAddition: async (workspace: Workspace, __, dependency: Descriptor) => {
+    afterWorkspaceDependencyAddition: async (
+      workspace: Workspace,
+      __,
+      dependency: Descriptor
+    ) => {
       fallbackDefaultAliasGroup(workspace, dependency);
     },
-    afterWorkspaceDependencyReplacement: async (workspace: Workspace, __, ___, dependency: Descriptor) => {
+    afterWorkspaceDependencyReplacement: async (
+      workspace: Workspace,
+      __,
+      ___,
+      dependency: Descriptor
+    ) => {
       fallbackDefaultAliasGroup(workspace, dependency);
     },
   },
 };
 
-async function fallbackDefaultAliasGroup(workspace: Workspace, dependency: Descriptor) {
+async function fallbackDefaultAliasGroup(
+  workspace: Workspace,
+  dependency: Descriptor
+) {
   if (dependency.range.startsWith(CATALOG_PROTOCOL)) {
     if (await configReader.shouldIgnoreWorkspace(workspace)) {
-      throw new Error(chalk.red(`The workspace is ignored from the catalogs, but the dependency to add is using the catalog protocol. Consider removing the protocol.`));
+      throw new Error(
+        chalk.red(
+          `The workspace is ignored from the catalogs, but the dependency to add is using the catalog protocol. Consider removing the protocol.`
+        )
+      );
     }
     return;
   }
 
   if (await configReader.shouldIgnoreWorkspace(workspace)) return;
 
-  const aliases = await configReader.findDependency(workspace.project, dependency);
+  const aliases = await configReader.findDependency(
+    workspace.project,
+    dependency
+  );
   if (aliases.length === 0) return;
 
   // If there's a default alias group, fallback to it
-  const defaultAliasGroups = await configReader.getDefaultAliasGroups(workspace);
+  const defaultAliasGroups = await configReader.getDefaultAliasGroups(
+    workspace
+  );
   if (defaultAliasGroups.length > 0) {
     for (const aliasGroup of defaultAliasGroups) {
       if (aliases.some(([alias]) => alias === aliasGroup)) {
@@ -158,17 +182,23 @@ async function fallbackDefaultAliasGroup(workspace: Workspace, dependency: Descr
         return;
       }
     }
-  };
+  }
 
   // If no default alias group is specified, show warning message
-  const aliasGroups = aliases.map(([aliasGroup]) => (
+  const aliasGroups = aliases.map(([aliasGroup]) =>
     aliasGroup === ROOT_ALIAS_GROUP ? "" : aliasGroup
-  ));
+  );
 
-  const aliasGroupsText = aliasGroups.filter(aliasGroup => aliasGroup !== "").length > 0
-    ? ` (${aliasGroups.join(", ")})` : "";
+  const aliasGroupsText =
+    aliasGroups.filter((aliasGroup) => aliasGroup !== "").length > 0
+      ? ` (${aliasGroups.join(", ")})`
+      : "";
 
-  console.warn(chalk.yellow(`➤ ${dependency.name} is listed in the catalogs config${aliasGroupsText}, but it seems you're adding it without the catalog protocol. Consider running 'yarn add ${dependency.name}@${CATALOG_PROTOCOL}${aliasGroups[0]}' instead.`));
+  console.warn(
+    chalk.yellow(
+      `➤ ${dependency.name} is listed in the catalogs config${aliasGroupsText}, but it seems you're adding it without the catalog protocol. Consider running 'yarn add ${dependency.name}@${CATALOG_PROTOCOL}${aliasGroups[0]}' instead.`
+    )
+  );
 }
 
 // Export the plugin factory

--- a/sources/index.ts
+++ b/sources/index.ts
@@ -42,7 +42,7 @@ const plugin: Plugin<Hooks & EssentialHooks> = {
       const hasCatalogProtocol = [
         ...Object.values(workspace.manifest.raw["dependencies"] || {}),
         ...Object.values(workspace.manifest.raw["devDependencies"] || {}),
-      ].some((version: string) => version.startsWith(CATALOG_PROTOCOL));
+      ].some((version) => (version as string).startsWith(CATALOG_PROTOCOL));
 
       if (await configReader.shouldIgnoreWorkspace(workspace) && hasCatalogProtocol) {
         report.reportError(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "experimentalDecorators": true,
     "module": "commonjs",
     "target": "ES2021",


### PR DESCRIPTION
- Mark `catalogs` & `list` as optional to avoid crashes when the option is not set in the `.yarnrc.yml`
- Enable `strict: true` in TS config to avoid not unsafe code

This is a fix for https://github.com/toss/yarn-plugin-catalogs/issues/12